### PR TITLE
[Chore] 회원가입 기능 구현을 위한 Github actions 수정 #11

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,21 +9,6 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    env:
-      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-      GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
-      REDIS_ENDPOINT: ${{ secrets.REDIS_ENDPOINT }}
-      REDIS_SECRET: ${{ secrets.REDIS_SECRET }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
-      DB_HOST: ${{ secrets.DB_HOST }}
-      DB_PORT: ${{ secrets.DB_PORT }}
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      NODE_ENV: ${{ secrets.NODE_ENV }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -40,20 +25,7 @@ jobs:
       - name: Build and push Docker image
         run: |
           IMAGE_TAG=${{ github.sha }}
-          docker build --build-arg GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID} \
-                       --build-arg GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET} \
-                       --build-arg GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI} \
-                       --build-arg REDIS_ENDPOINT=${REDIS_ENDPOINT} \
-                       --build-arg REDIS_SECRET=${REDIS_SECRET} \
-                       --build-arg JWT_SECRET=${JWT_SECRET} \
-                       --build-arg JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET} \
-                       --build-arg DB_HOST=${DB_HOST} \
-                       --build-arg DB_PORT=${DB_PORT} \
-                       --build-arg DB_USER=${DB_USER} \
-                       --build-arg DB_PASSWORD=${DB_PASSWORD} \
-                       --build-arg DB_NAME=${DB_NAME} \
-                       --build-arg NODE_ENV=${NODE_ENV} \
-                       -t dukovkodev335/melodiary-server:${IMAGE_TAG} .
+          docker build -t dukovkodev335/melodiary-server:${IMAGE_TAG} .
           docker tag dukovkodev335/melodiary-server:${IMAGE_TAG} dukovkodev335/melodiary-server:latest
           docker push dukovkodev335/melodiary-server:${IMAGE_TAG}
           docker push dukovkodev335/melodiary-server:latest


### PR DESCRIPTION
## 📝 작업 내용

- 이슈 번호 : #11 
- .env 파일을 수동으로 EC2 인스턴스에 올리도록 수정
- Github actions에서는 docker 자격증명만 사용하도록 수정

## ⭐ 작업 상세 설명

- 환경변수들을 github secrets에 두고 사용하면 docker image에 환경변수가 포함되는 문제가 있었습니다.
- 현재 docker hub repository는 public 상태이므로, 누구나 docker image를 pull 할 수 있고, 내부의 환경변수를 볼 수 있는 상태입니다.
- 따라서 환경변수를 docker image에 포함시키지 않고, 컨테이너를 구동할때 .env 파일을 마운트하도록 수정했습니다.
- 이제 Github actions workflow는 docker 자격증명만 참조합니다.
- .env 파일은 AWS secrets manager를 사용할 수도 있지만, 비용이 발생하기 때문에 사용하지 않았습니다.
- 배포환경에서 사용할 .env 파일은 수동으로 EC2 인스턴스에 복사해야 합니다.
- .env 파일 충돌 문제를 방지하기 위해, .env 파일을 복사하기 전에 협의가 필요합니다.
