### PR TITLE
[Fix] auth middleware 수정 #26

### DIFF
--- a/docs/API_spec.yaml
+++ b/docs/API_spec.yaml
@@ -5,7 +5,7 @@ info:
     ### 당신의 하루를 음악과 함께 기록하세요.
   contact:
     email: melodiary@gmail.com
-  version: 1.0.1
+  version: 1.0.2
 servers:
   - url: https://api.melodiary.site
 tags:
@@ -153,6 +153,8 @@ paths:
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
 
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
+
         사용자가 존재하지 않는 경우 404 코드를 리턴합니다.
 
         그 이외의 경우 500 코드를 리턴합니다.
@@ -176,6 +178,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 존재하지 않는 사용자
           content:
@@ -205,6 +216,8 @@ paths:
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
 
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
+
         사용자가 존재하지 않는 경우 404 코드를 리턴합니다.
 
         그 이외의 경우 500 코드를 리턴합니다.
@@ -231,6 +244,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 존재하지 않는 사용자
           content:
@@ -319,6 +341,8 @@ paths:
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
 
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
+
         사용자가 존재하지 않는 경우 404 코드를 리턴합니다.
 
         중복된 닉네임일 경우 409 코드를 리턴합니다.
@@ -363,6 +387,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 존재하지 않는 사용자
           content:
@@ -402,6 +435,8 @@ paths:
         요청 구문이 잘못된 경우 400 코드를 리턴합니다.
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
+
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
 
         사용자가 존재하지 않는 경우 404 코드를 리턴합니다.
 
@@ -447,6 +482,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 존재하지 않는 사용자
           content:
@@ -488,6 +532,8 @@ paths:
         요청의 이미지 URL이 유효하지 않은 경우 400 코드를 리턴합니다.
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
+
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
 
         사용자가 존재하지 않는 경우 404 코드를 리턴합니다.
 
@@ -531,6 +577,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 존재하지 않는 사용자
           content:
@@ -561,6 +616,8 @@ paths:
         요청의 이미지 URL이 유효하지 않은 경우 400 코드를 리턴합니다.
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
+
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
 
         기존에 등록된 프로필 사진이 없는 경우 404 코드를 리턴합니다.
 
@@ -604,6 +661,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 기존에 등록된 프로필 사진이 없음
           content:
@@ -636,6 +702,8 @@ paths:
         요청의 이미지 URL이 유효하지 않은 경우 400 코드를 리턴합니다.
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
+
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
 
         사용자가 존재하지 않는 경우 404 코드를 리턴합니다.
 
@@ -679,6 +747,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 존재하지 않는 사용자
           content:
@@ -709,6 +786,8 @@ paths:
         요청의 이미지 URL이 유효하지 않은 경우 400 코드를 리턴합니다.
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
+
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
 
         기존에 등록된 마이페이지 배경 사진이 없는 경우 404 코드를 리턴합니다.
 
@@ -752,6 +831,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 기존에 등록된 마이페이지 배경 사진이 없음
           content:
@@ -846,6 +934,8 @@ paths:
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
 
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
+
         사용자가 존재하지 않는 경우 404 코드를 리턴합니다.
 
         그 이외의 경우 500 코드를 리턴합니다.
@@ -872,6 +962,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 존재하지 않는 사용자
           content:
@@ -964,6 +1063,8 @@ paths:
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
 
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
+
         친구로 등록된 사용자가 없는 경우 404 코드를 리턴합니다.
 
         그 이외의 경우 500 코드를 리턴합니다.
@@ -989,6 +1090,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 친구로 등록된 사용자가 없음
           content:
@@ -1019,6 +1129,8 @@ paths:
         요청 구문이 잘못된 경우 400 코드를 리턴합니다.
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
+
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
 
         친구 요청 받을 사용자가 존재하지 않는 경우 404 코드를 리턴합니다.
 
@@ -1061,6 +1173,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 친구로 등록된 사용자가 없음
           content:
@@ -1103,6 +1224,8 @@ paths:
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
 
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
+
         친구ID에 해당하는 사용자가 존재하지 않는 경우 404 코드를 리턴합니다.
 
         그 이외의 경우 500 코드를 리턴합니다.
@@ -1139,6 +1262,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 친구ID에 해당하는 사용자가 존재하지 않음
           content:
@@ -1170,6 +1302,8 @@ paths:
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
 
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
+
         받은 친구 요청이 없는 경우 404 코드를 리턴합니다.
 
         그 이외의 경우 500 코드를 리턴합니다.
@@ -1195,6 +1329,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 받은 친구 요청이 없음
           content:
@@ -1226,6 +1369,8 @@ paths:
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
 
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
+
         보낸 친구 요청이 없는 경우 404 코드를 리턴합니다.
 
         그 이외의 경우 500 코드를 리턴합니다.
@@ -1251,6 +1396,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 보낸 친구 요청이 없음
           content:
@@ -1283,6 +1437,8 @@ paths:
         요청 구문이 잘못된 경우 400 코드를 리턴합니다.
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
+
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
 
         친구요청ID에 해당하는 요청이 존재하지 않는 경우 404 코드를 리턴합니다.
 
@@ -1320,6 +1476,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 친구요청ID에 해당하는 요청이 존재하지 않음
           content:
@@ -1350,6 +1515,8 @@ paths:
         요청 구문이 잘못된 경우 400 코드를 리턴합니다.
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
+
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
 
         친구요청ID에 해당하는 요청이 존재하지 않는 경우 404 코드를 리턴합니다.
 
@@ -1387,6 +1554,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 친구요청ID에 해당하는 요청이 존재하지 않음
           content:
@@ -1417,6 +1593,8 @@ paths:
         읽지 않은 알림이 있는 경우 200 코드와 읽지 않은 알림 목록을 리턴합니다.
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
+
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
 
         읽지 않은 알림이 없는 경우 404 코드를 리턴합니다.
 
@@ -1456,6 +1634,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 읽지 않은 알림 없음
           content:
@@ -1486,6 +1673,8 @@ paths:
         읽은 알림이 있는 경우 200 코드와 읽은 알림 목록을 리턴합니다.
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
+
+        다른 사용자의 정보에 접근하는 경우 403 코드를 리턴합니다.
 
         읽은 알림이 없는 경우 404 코드를 리턴합니다.
 
@@ -1525,6 +1714,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '403':
+          description: 액세스 금지됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Forbidden: User ID mismatch'
         '404':
           description: 읽은 알림 없음
           content:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
-        "@types/express": "^4.17.11",
+        "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/morgan": "^1.9.9",
         "@types/swagger-ui-express": "^4.1.6",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
-    "@types/express": "^4.17.11",
+    "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/morgan": "^1.9.9",
     "@types/swagger-ui-express": "^4.1.6",

--- a/src/controllers/diariesController.ts
+++ b/src/controllers/diariesController.ts
@@ -19,6 +19,9 @@ export const postDiary = async (req: Request, res: Response) => {
       weather
     }: IPostDiary = req.body;
 
+    // 아래와 같은 방식으로 토큰의 사용자 ID 사용하시면 됩니다!
+    // const tokenUserID = (req.user as JwtPayload).userId;
+
     // diary 테이블에 데이터 삽입
     const diaryQuery = `INSERT INTO diary (title, content, user_id, mood, emoji, privacy, background_color) 
                       VALUES (?, ?, ?, ?, ?, ?, ?)`;

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,5 +1,6 @@
 // 사용자 관련 요청을 처리하는 controller
 import { Request, Response } from 'express';
+import { JwtPayload } from 'jsonwebtoken';
 import {
   googleSignUpService,
   googleLoginService,
@@ -145,9 +146,15 @@ export const nicknameController = {
   register: async (req: Request, res: Response) => {
     try {
       const { userID } = req.params;
+      const tokenUserID = (req.user as JwtPayload).userId;
       const { nickname } = req.body;
 
       const parsedUserID = parseInt(userID, 10);
+
+      // 접근권한이 없는 경우 403 코드 리턴함
+      if (parsedUserID !== Number(tokenUserID)) {
+        return res.status(403).json({ message: 'Forbidden: User ID mismatch' });
+      }
 
       // 요청 구문이 잘못된 경우 400 코드 리턴함
       if (isNaN(parsedUserID) || typeof nickname !== 'string' || !nickname) {
@@ -192,9 +199,15 @@ export const nicknameController = {
   update: async (req: Request, res: Response) => {
     try {
       const { userID } = req.params;
+      const tokenUserID = (req.user as JwtPayload).userId;
       const { nickname } = req.body;
 
       const parsedUserID = parseInt(userID, 10);
+
+      // 접근권한이 없는 경우 403 코드 리턴함
+      if (parsedUserID !== Number(tokenUserID)) {
+        return res.status(403).json({ message: 'Forbidden: User ID mismatch' });
+      }
 
       // 요청 구문이 잘못된 경우 400 코드 리턴함
       if (isNaN(parsedUserID) || typeof nickname !== 'string' || !nickname) {

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -21,14 +21,12 @@ export const verifyTokenMiddleware = async (
   try {
     // 토큰 검증
     const decoded = (await verifyAccessToken(token)) as JwtPayload;
-    const { userID } = req.params;
-    const tokenUserID = decoded.userId;
+    req.user = decoded;
 
-    if (userID !== String(tokenUserID)) {
-      return res.status(403).json({ message: 'Forbidden: User ID mismatch' });
-    }
     next(); // 다음 미들웨어 또는 라우트 핸들러로 이동
   } catch (error) {
-    return res.status(403).json({ message: 'Invalid or expired token' });
+    return res
+      .status(401)
+      .json({ message: 'The access token is invalid or expired' });
   }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,10 @@
     "esModuleInterop": true,
     "lib": ["es2020", "dom"],
     "moduleResolution": "node",
+    "typeRoots": ["./types", "./node_modules/@types"],
     "outDir": "./build",
     "rootDir": "."
   },
-  "include": ["src/**/*.ts", "app.ts"],
+  "include": ["src/**/*.ts", "types/**/*.ts", "app.ts"],
   "exclude": ["node_modules", "build"]
 }

--- a/types/express.d.ts
+++ b/types/express.d.ts
@@ -1,0 +1,10 @@
+// types/express.d.ts
+import { JwtPayload } from 'jsonwebtoken';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: JwtPayload;
+    }
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용

- 이슈 번호 : #26 
- authMiddleware 수정
- API 명세서 403 응답 추가

## ⭐ 작업 상세 설명

- authMiddleware가 토큰의 존재여부만 확인하고 토큰의 내용은  req.user에 담아서 각 API로 보내도록 수정했습니다.
- 이제 authMiddleware를 사용하는 각 API에서 `const tokenUserID = (req.user as JwtPayload).userId;` 형식으로 토큰의 사용자 ID를 꺼내 사용할 수 있습니다.
- 유저 관련 API에서 토큰의 사용자 ID와 접근하는 정보의 소유자가 다를 경우 403 에러를 응답하도록 수정했습니다.
- API 명세서에도 403 응답을 명시했습니다.
