### PR TITLE
[Feat]add features about 1 day 1 diary

### DIFF
--- a/docs/API_spec.yaml
+++ b/docs/API_spec.yaml
@@ -1921,6 +1921,8 @@ paths:
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
 
+        오늘 작성한 일기가 이미 있다면 409 코드를 리턴합니다.
+
         그 이외의 경우 500 코드를 리턴합니다.
 
       security:
@@ -1957,6 +1959,15 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'The access token is invalid or expired'
+        '409':
+          description: 같은 날 작성한 일기가 이미 존재함.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'Already posted diary today'        
 
         '500':
           description: 내부 서버 에러
@@ -2552,6 +2563,10 @@ paths:
         - diary
       summary: 작성한 일기 목록 조회
       description: |
+
+        ?page=(페이지번호,기본값:1)&limit=(가져올row수, 기본값:5)
+
+
         일기 목록 조회에 성공한 경우 200코드와 일기 목록을 리턴합니다.
 
         Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
@@ -2559,6 +2574,9 @@ paths:
         그 이외의 경우 500 코드를 리턴합니다.
       security:
         - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Limit'
       responses:
         '200':
           description: 내 일기 목록 조회
@@ -2911,6 +2929,48 @@ paths:
                   - $ref: '#/components/schemas/Message'
                 example:
                   message: 'There is something wrong with the server'
+  
+  /api/diaries/today:
+    get:
+      tags:
+        - diary
+      summary: 오늘의 일기 작성 여부 조회
+      description: |
+      
+        오늘의 일기 작성 여부 조회에 성공한 경우 200코드와 정보를 리턴합니다.
+
+        Access token이 유효하지 않을 경우 401 코드를 리턴합니다. 이 경우 access token을 재발급 받아야 합니다.
+
+        그 이외의 경우 500 코드를 리턴합니다.
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: 오늘의 일기 작성 여부
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HasPosts'
+
+        '401':
+          description: Access token이 유효하지 않거나 만료됨
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'The access token is invalid or expired'
+
+        '500':
+          description: 내부 서버 에러
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Message'
+                example:
+                  message: 'There is something wrong with the server'
   /api/weather:
     get:
       tags:
@@ -2987,7 +3047,7 @@ paths:
         - $ref: '#/components/parameters/Limit'
       responses:
         '200':
-          description: 일기 음악 정보
+          description: 일기 플레이리스트 정보
           content:
             application/json:
               schema:
@@ -2995,6 +3055,10 @@ paths:
                 properties:
                   user_profile:
                     $ref: '#/components/schemas/ProfileInfo'
+                  total_count:
+                    type: integer
+                    example: 55  
+                    description: 플레이리스트 총 갯수                  
                   musics:
                     type: array
                     items:
@@ -3002,6 +3066,7 @@ paths:
                         - $ref: '#/components/schemas/MusicInfo'
                         - type: object
                           properties:
+
                             created_at:
                               type: string
                               format: date

--- a/docs/API_spec.yaml
+++ b/docs/API_spec.yaml
@@ -2583,16 +2583,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  total_count:
-                    type: integer
-                    example: 55  
-                    description: 플레이리스트 총 갯수
-                  diaries:                
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/DiaryInfo'
+                type: array
+                items:
+                  $ref: '#/components/schemas/DiaryInfo'
         '401':
           description: Access token이 유효하지 않거나 만료됨
           content:

--- a/docs/API_spec.yaml
+++ b/docs/API_spec.yaml
@@ -2583,9 +2583,16 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DiaryInfo'
+                type: object
+                properties:
+                  total_count:
+                    type: integer
+                    example: 55  
+                    description: 플레이리스트 총 갯수
+                  diaries:                
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DiaryInfo'
         '401':
           description: Access token이 유효하지 않거나 만료됨
           content:
@@ -3066,7 +3073,6 @@ paths:
                         - $ref: '#/components/schemas/MusicInfo'
                         - type: object
                           properties:
-
                             created_at:
                               type: string
                               format: date

--- a/src/controllers/diariesController.ts
+++ b/src/controllers/diariesController.ts
@@ -171,7 +171,7 @@ export const putDiary = async (req: Request, res: Response) => {
       [diaryId]
     );
 
-    if (checkRows.length === 0) {
+    if (checkRows.length == 0) {
       return res.status(404).json({ message: 'Not Found that diary' });
     }
     if (checkRows[0].user_id != userId) {
@@ -284,9 +284,9 @@ export const deleteDiary = async (req: Request, res: Response) => {
     const checkQuery = `SELECT * FROM diary WHERE id = ?`;
     const [checkRows] = await dbConnection.execute<RowDataPacket[]>(
       checkQuery,
-      [diaryId, userId]
+      [diaryId]
     );
-    if (checkRows.length === 0) {
+    if (checkRows.length == 0) {
       return res.status(404).json({ message: 'Not Found that diary' });
     }
     if (checkRows[0].user_id != userId) {
@@ -371,7 +371,7 @@ export const getDiary = async (req: Request, res: Response) => {
       diaryId
     ]);
 
-    if (rows.length === 0) {
+    if (rows.length == 0) {
       return res.status(404).json({ message: 'Not Found that diary' });
     }
     const row = rows[0];
@@ -418,7 +418,7 @@ export const getLike = async (req: Request, res: Response) => {
       [diaryId]
     );
 
-    if (checkRows.length === 0) {
+    if (checkRows.length == 0) {
       return res.status(404).json({ message: 'Not Found that diary' });
     }
 
@@ -481,7 +481,7 @@ export const postLike = async (req: Request, res: Response) => {
       checkQuery,
       [diaryId]
     );
-    if (checkRows.length === 0) {
+    if (checkRows.length == 0) {
       return res.status(404).json({ message: 'Not Found that diary' });
     }
 

--- a/src/controllers/diariesController.ts
+++ b/src/controllers/diariesController.ts
@@ -857,21 +857,13 @@ export const getMypost = async (req: Request, res: Response) => {
       [userId, userId]
     );
 
-    const countQuery = `SELECT FOUND_ROWS() as total`;
-    const [[{ total }]] = await dbConnection.execute<RowDataPacket[]>(
-      countQuery
-    );
-
     const diaryInfos = await Promise.all(
       diaryRows.map((row) => {
         return convertDiaryInfo(row);
       })
     );
 
-    res.status(200).json({
-      total_count: total,
-      diaries: diaryInfos
-    });
+    res.status(200).json(diaryInfos);
   } catch (error) {
     console.error(error);
     res

--- a/src/routes/diaries.ts
+++ b/src/routes/diaries.ts
@@ -11,7 +11,8 @@ import {
   getMatefeeds,
   getExplore,
   getMymoods,
-  getMypost
+  getMypost,
+  getToday
 } from '../controllers/diariesController.js';
 import { verifyTokenMiddleware } from '../middlewares/authMiddleware.js';
 import commentRouter from './comments.js';
@@ -27,6 +28,7 @@ router.get('/mates', verifyTokenMiddleware, getMatefeeds);
 router.get('/explore', verifyTokenMiddleware, getExplore);
 router.get('/myposts', verifyTokenMiddleware, getMypost);
 router.get('/mymoods', verifyTokenMiddleware, getMymoods);
+router.get('/today', verifyTokenMiddleware, getToday);
 
 router.post('/', verifyTokenMiddleware, postDiary);
 router.put('/:diaryId', verifyTokenMiddleware, putDiary);


### PR DESCRIPTION
## 📝 작업 내용

- 이슈 번호 : ex) #53 
- 플레이리스트 조회 시 플레이리스트의 전체 갯수도 함께 반환
- 오늘 일기 작성했는지 여부를 확인하는 API 추가
- 내가 작성한 일기 목록 조회 시 일기 총 수도 함께 반환

## ⭐ 작업 상세 설명

- POST /api/diaries 시, 금일에 작성한 일기가 이미 있다면 409 코드를 반환하고 일기가 작성되지 않습니다.

- GET /api/users/{userID}/music 시 total_count 로 플레이리스트의 총 개수도 함께 반환합니다.
![image](https://github.com/user-attachments/assets/358ca72a-50e8-4a4a-88df-1874cde53309)

- GET /api/diaries/today 시 오늘 일기 작성한 일기가 있다면 has_posts: true (또 작성할 수 없음), 없다면 false (작성 가능)을 반환합니다.

## 💬 리뷰 요구사항(선택)

- ex) 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
