### PR TITLE
[Fix] 이미지 업로드 API 수정 #64

### DIFF
--- a/src/controllers/awsController.ts
+++ b/src/controllers/awsController.ts
@@ -5,8 +5,13 @@ import { s3ImageUploadUrlService } from '../services/awsService.js';
 // S3 버킷 이미지 업로드 controller
 export const s3ImageUploadController = async (req: Request, res: Response) => {
   try {
-    const filenames = req.body['filenames'];
+    let filenames = req.body['filenames'];
     const files = req.files as Express.Multer.File[];
+
+    // 이미지 하나만 업로드하는 경우 파일명을 배열로 변환
+    if (typeof filenames === 'string') {
+      filenames = [filenames];
+    }
 
     // 요청 구문이 잘못된 경우 400 코드 리턴함
     if (!Array.isArray(filenames) || filenames.length !== files.length) {


### PR DESCRIPTION
## 📝 작업 내용

- 이슈 번호 : #64 
- awsController 모듈 수정

## ⭐ 작업 상세 설명

- 기존 API는 여러개의 이미지를 업로드 한다는 가정 하에, 파일명이 배열이 아니면 400 에러를 응답하도록 작성했습니다.
- 하나의 이미지만 업로드 요청을 보내면 파일명이 문자열로 받아져서 400 에러를 응답하는 오류가 있었습니다.
- 이미지 하나만 업로드 하는 경우 파일명을 배열로 변환하도록 하여 정상적으로 업로드 되도록 수정했습니다.
